### PR TITLE
Use a static API version for endpoints

### DIFF
--- a/lib/envato/client/stats.rb
+++ b/lib/envato/client/stats.rb
@@ -2,19 +2,19 @@ module Envato
   class Client
     module Stats
       def total_users
-        response = get 'market/total-users.json'
+        response = get 'v1/market/total-users.json'
         response['total-users']['total_users'].to_i
       end
 
       def total_items
-        response = get 'market/total-items.json'
+        response = get 'v1/market/total-items.json'
         response['total-items']['total_items'].to_i
       end
 
       def category_information_by_site(sitename)
         raise Envato::InvalidSiteName unless marketplace_names.include? sitename
 
-        response = get "market/number-of-files:#{sitename}.json"
+        response = get "v1/market/number-of-files:#{sitename}.json"
         response['number-of-files']
       end
 

--- a/lib/envato/connection.rb
+++ b/lib/envato/connection.rb
@@ -15,10 +15,6 @@ module Envato
       'https://api.envato.com'
     end
 
-    def api_version
-      'v1'
-    end
-
     private
 
     def request(method, url, options = {})
@@ -31,7 +27,7 @@ module Envato
 
       case method
       when :get
-        response = request.get "#{api_version}/#{url}"
+        response = request.get(url)
       end
 
       case response.status.to_i

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 describe Envato::Client do
-  let(:api_host)    { 'https://api.envato.com' }
-  let(:api_version) { 'v1' }
-  let(:client)      { described_class.new(:access_token => test_api_token) }
+  let(:api_host) { 'https://api.envato.com' }
+  let(:client)   { described_class.new(:access_token => test_api_token) }
 
   describe '.new' do
     it 'raises an error when the API access token is missing' do

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -14,15 +14,11 @@ describe Envato::Connection do
     it { expect(client.api_host).to be_a(String) }
   end
 
-  describe '#api_version' do
-    it { expect(client.api_version).to be_a(String) }
-  end
-
   describe '.get' do
     context 'with valid JSON response' do
       it 'is a hash' do
         VCR.use_cassette('client/valid_response') do
-          expect(client.get('market/total-items.json')).to be_a(Hash)
+          expect(client.get('v1/market/total-items.json')).to be_a(Hash)
         end
       end
     end
@@ -30,7 +26,7 @@ describe Envato::Connection do
     context 'server errors' do
       it 'raise a ServerError' do
         VCR.use_cassette('client/server_error') do
-          expect { client.get('market/active-threads:themeforest.net') }.to raise_error(Envato::ServerError)
+          expect { client.get('v1/market/active-threads:themeforest.net') }.to raise_error(Envato::ServerError)
         end
       end
     end
@@ -41,7 +37,7 @@ describe Envato::Connection do
           # Kill off the access token we've defined to force the authentication
           # to fail.
           client.access_token = ''
-          expect { client.get('market/non-existent-url') }.to raise_error(Envato::ForbiddenError)
+          expect { client.get('v1/market/non-existent-url') }.to raise_error(Envato::ForbiddenError)
         end
       end
     end
@@ -49,7 +45,7 @@ describe Envato::Connection do
     context 'not found requests' do
       it 'raise a NotFoundError' do
         VCR.use_cassette('client/not_found') do
-          expect { client.get('market/non-existent-url') }.to raise_error(Envato::NotFoundError)
+          expect { client.get('v1/market/non-existent-url') }.to raise_error(Envato::NotFoundError)
         end
       end
     end


### PR DESCRIPTION
In it's current state, the API has some magic at the routing tier that
determines which backend to send the request to based on the version provided in
the URL which means we cannot set a global API version across the board for all
endpoints. This is being worked on and in the future will do some sane
versioning so that a global version can be provided.
