### PR TITLE
Symbolize response keys

### DIFF
--- a/lib/envato/client/catalog.rb
+++ b/lib/envato/client/catalog.rb
@@ -3,7 +3,7 @@ module Envato
     module Catalog
       def get_public_collection(collection_id)
         response = get "v3/market/catalog/collection?id=#{collection_id}"
-        response['collection']
+        response[:collection]
       end
 
       def get_item(item_id)
@@ -14,33 +14,33 @@ module Envato
         raise Envato::InvalidSiteName unless marketplace_names.include? sitename
 
         response = get "v1/market/popular:#{sitename}.json"
-        response['popular']
+        response[:popular]
       end
 
       def categories_by_site(sitename)
         raise Envato::InvalidSiteName unless marketplace_names.include? sitename
 
         response = get "v1/market/categories:#{sitename}.json"
-        response['categories']
+        response[:categories]
       end
 
       def prices_for_item(item_id)
         response = get "v1/market/item-prices:#{item_id}.json"
-        response['item-prices']
+        response[:'item-prices']
       end
 
       def featured_by_site(sitename)
         raise Envato::InvalidSiteName unless marketplace_names.include? sitename
 
         response = get "v1/market/features:#{sitename}.json"
-        response['features']
+        response[:features]
       end
 
       def random_new_items_by_site(sitename)
         raise Envato::InvalidSiteName unless marketplace_names.include? sitename
 
         response = get "v1/market/random-new-files:#{sitename}.json"
-        response['random-new-files']
+        response[:'random-new-files']
       end
     end
   end

--- a/lib/envato/client/stats.rb
+++ b/lib/envato/client/stats.rb
@@ -3,19 +3,19 @@ module Envato
     module Stats
       def total_users
         response = get 'v1/market/total-users.json'
-        response['total-users']['total_users'].to_i
+        response[:'total-users'][:total_users].to_i
       end
 
       def total_items
         response = get 'v1/market/total-items.json'
-        response['total-items']['total_items'].to_i
+        response[:'total-items'][:total_items].to_i
       end
 
       def category_information_by_site(sitename)
         raise Envato::InvalidSiteName unless marketplace_names.include? sitename
 
         response = get "v1/market/number-of-files:#{sitename}.json"
-        response['number-of-files']
+        response[:'number-of-files']
       end
     end
   end

--- a/lib/envato/client/user.rb
+++ b/lib/envato/client/user.rb
@@ -3,49 +3,49 @@ module Envato
     module User
       def account_details
         response = get 'v1/market/private/user/account.json'
-        response['account']
+        response[:account]
       end
 
       def username
         response = get 'v1/market/private/user/username.json'
-        response['username']
+        response[:username]
       end
 
       def email_address
         response = get 'v1/market/private/user/email.json'
-        response['email']
+        response[:email]
       end
 
       def user_information(username)
         response = get "v1/market/user:#{username}.json"
-        response['user']
+        response[:user]
       end
 
       def badges_for_user(username)
         response = get "v1/market/user-badges:#{username}.json"
-        response['user-badges']
+        response[:'user-badges']
       end
 
       def user_items_by_site(username)
         response = get "v1/market/user-items-by-site:#{username}.json"
-        response['user-items-by-site']
+        response[:'user-items-by-site']
       end
 
       def new_items_for_user(username, sitename)
         raise Envato::InvalidSiteName unless marketplace_names.include? sitename
 
         response = get "v1/market/new-files-from-user:#{username},#{sitename}.json"
-        response['new-files-from-user']
+        response[:'new-files-from-user']
       end
 
       def sales_per_month
         response = get 'v1/market/private/user/earnings-and-sales-by-month.json'
-        response['earnings-and-sales-by-month']
+        response[:'earnings-and-sales-by-month']
       end
 
       def user_statement
         response = get 'v1/market/private/user/statement.json'
-        response['statement']
+        response[:statement]
       end
 
       def sales(page = 1)

--- a/lib/envato/connection.rb
+++ b/lib/envato/connection.rb
@@ -4,7 +4,7 @@ require 'json'
 module Envato
   module Connection
     def get(url)
-      request :get, url
+      request(:get, url)
     end
 
     def ssl_opts
@@ -38,7 +38,7 @@ module Envato
       end
 
       begin
-        JSON.parse(response.body)
+        symbolize(JSON.parse(response.body))
       rescue JSON::ParserError
         response.body
       end
@@ -57,6 +57,18 @@ module Envato
     def extract_server_error_message(response)
       body = JSON.parse(response.body)
       body['message'] if body['message']
+    end
+
+    def symbolize(obj)
+      return obj.reduce({}) do |memo, (k, v)|
+        memo.tap { |m| m[k.to_sym] = symbolize(v) }
+      end if obj.is_a? Hash
+
+      return obj.reduce([]) do |memo, v|
+        memo << symbolize(v); memo
+      end if obj.is_a? Array
+
+      obj
     end
   end
 end

--- a/spec/client/catalog_spec.rb
+++ b/spec/client/catalog_spec.rb
@@ -20,7 +20,7 @@ describe Envato::Client::Catalog do
         public_collection = client.get_public_collection(valid_collection_id)
 
         required_response_keys.each do |key|
-          expect(public_collection).to have_key(key)
+          expect(public_collection).to have_key(key.to_sym)
         end
       end
     end
@@ -42,7 +42,7 @@ describe Envato::Client::Catalog do
         public_collection = client.get_item(valid_item_id)
 
         required_response_keys.each do |key|
-          expect(public_collection).to have_key(key)
+          expect(public_collection).to have_key(key.to_sym)
         end
       end
     end
@@ -51,7 +51,7 @@ describe Envato::Client::Catalog do
       it 'is an array' do
         VCR.use_cassette('client/catalog/get_item') do
           public_collection = client.get_item(valid_item_id)
-          expect(public_collection['attributes']).to be_a(Array)
+          expect(public_collection[:attributes]).to be_a(Array)
         end
       end
     end
@@ -73,7 +73,7 @@ describe Envato::Client::Catalog do
           required_response_keys = %w(items_last_week authors_last_month)
 
           required_response_keys.each do |key|
-            expect(popular_items).to have_key(key)
+            expect(popular_items).to have_key(key.to_sym)
           end
         end
       end
@@ -115,7 +115,7 @@ describe Envato::Client::Catalog do
           featured = client.featured_by_site(valid_marketplace)
 
           required_keys.each do |key|
-            expect(featured).to have_key(key)
+            expect(featured).to have_key(key.to_sym)
           end
         end
       end

--- a/spec/client/stats_spec.rb
+++ b/spec/client/stats_spec.rb
@@ -33,7 +33,7 @@ describe Envato::Client::Stats do
           sample_category = client.category_information_by_site('themeforest').first
 
           required_response_keys.each do |key|
-            expect(sample_category).to have_key(key)
+            expect(sample_category).to have_key(key.to_sym)
           end
         end
       end

--- a/spec/client/user_spec.rb
+++ b/spec/client/user_spec.rb
@@ -10,7 +10,7 @@ describe Envato::Client::User do
         account_details = client.account_details
 
         required_account_keys.each do |key|
-          expect(account_details).to have_key(key)
+          expect(account_details).to have_key(key.to_sym)
         end
       end
     end
@@ -39,7 +39,7 @@ describe Envato::Client::User do
         user_information = client.user_information 'collis'
 
         required_user_keys.each do |key|
-          expect(user_information).to have_key(key)
+          expect(user_information).to have_key(key.to_sym)
         end
       end
     end
@@ -47,7 +47,7 @@ describe Envato::Client::User do
     it 'returns the image over HTTPS' do
       VCR.use_cassette('client/user/user_information') do
         user_information = client.user_information 'collis'
-        expect(user_information['image']).to start_with 'https://'
+        expect(user_information[:image]).to start_with 'https://'
       end
     end
   end
@@ -66,7 +66,7 @@ describe Envato::Client::User do
       user_badge = user_badges.first
 
       required_badge_keys.each do |key|
-        expect(user_badge).to have_key(key)
+        expect(user_badge).to have_key(key.to_sym)
       end
     end
   end
@@ -98,7 +98,7 @@ describe Envato::Client::User do
         items_by_site = user_with_items.first
 
         required_item_keys.each do |key|
-          expect(items_by_site).to have_key(key)
+          expect(items_by_site).to have_key(key.to_sym)
         end
       end
     end
@@ -146,7 +146,7 @@ describe Envato::Client::User do
           new_item_by_user   = valid_request_with_items.first
 
           required_item_keys.each do |key|
-            expect(new_item_by_user).to have_key(key)
+            expect(new_item_by_user).to have_key(key.to_sym)
           end
         end
       end
@@ -201,7 +201,7 @@ describe Envato::Client::User do
       it 'has required keys' do
         required_keys = %w(month earnings sales)
         required_keys.each do |key|
-          expect(author_with_sales_request.first).to have_key(key)
+          expect(author_with_sales_request.first).to have_key(key.to_sym)
         end
       end
     end
@@ -234,7 +234,7 @@ describe Envato::Client::User do
       it 'has required keys' do
         required_keys = %w(kind amount description occured_at)
         required_keys.each do |key|
-          expect(user_statement_with_activity.first).to have_key(key)
+          expect(user_statement_with_activity.first).to have_key(key.to_sym)
         end
       end
     end
@@ -261,12 +261,12 @@ describe Envato::Client::User do
       it 'has required keys' do
         required_keys = %w(amount sold_at item license support_amount supported_until)
         required_keys.each do |key|
-          expect(valid_sales_request.first).to have_key(key)
+          expect(valid_sales_request.first).to have_key(key.to_sym)
         end
       end
 
       it 'item key is a hash of details' do
-        expect(valid_sales_request.first['item']).to be_a(Hash)
+        expect(valid_sales_request.first[:item]).to be_a(Hash)
       end
     end
   end
@@ -290,12 +290,12 @@ describe Envato::Client::User do
       it 'includes required keys' do
         required_keys = %w(sold_at item license support_amount supported_until buyer purchase_count)
         required_keys.each do |key|
-          expect(valid_purchase_request).to have_key(key)
+          expect(valid_purchase_request).to have_key(key.to_sym)
         end
       end
 
       it 'includes the item' do
-        expect(valid_purchase_request['item']).to be_a(Hash)
+        expect(valid_purchase_request[:item]).to be_a(Hash)
       end
     end
   end


### PR DESCRIPTION
This converts all the keys within the response to be symbols instead of
strings. I feel this is more Ruby-like and what the users would be more
accustom to.

Fixes #19
